### PR TITLE
Removed false force touch invocation

### DIFF
--- a/Yoshi/Yoshi/Yoshi.swift
+++ b/Yoshi/Yoshi/Yoshi.swift
@@ -66,9 +66,13 @@ public final class Yoshi {
         }
 
         let eventTouches = event?.allTouches()?.filter({ (touch) -> Bool in
-            guard let percent: CGFloat = CGFloat(minimumForcePercent) else {
+            // Guarding against touch.maximumPossibleForce > 0
+            // because this value is 0 on non-3D touch capable devices
+            guard touch.maximumPossibleForce > 0 else {
                 return false
             }
+
+            let percent = CGFloat(minimumForcePercent)
             return touch.force >= touch.maximumPossibleForce * (percent / 100)
         })
 


### PR DESCRIPTION
For iOS 9 devices without 3D touch,

`force.touch` would equate to 0, and `touch.maximumPossibleForce` would also equal 0