### PR TITLE
Added a selection for dates.

### DIFF
--- a/Example/YoshiExample/MenuItem.swift
+++ b/Example/YoshiExample/MenuItem.swift
@@ -39,12 +39,22 @@ struct TableViewMenu: YoshiTableViewMenu {
 /**
  *  A date selector menu item to be displayed in Yoshi.
  */
-struct DateSelector: YoshiDateSelectorMenu {
+internal final class DateSelector: YoshiDateSelectorMenu {
 
     var title: String
     var subtitle: String?
+    var selectedDate: NSDate
     var didUpdateDate: (dateSelected: NSDate) -> ()
 
+    init(title: String,
+         subtitle: String? = nil,
+         selectedDate: NSDate = NSDate(),
+         didUpdateDate: (NSDate) -> ()) {
+        self.title = title
+        self.subtitle = subtitle
+        self.selectedDate = selectedDate
+        self.didUpdateDate = didUpdateDate
+    }
 }
 
 /**

--- a/Yoshi/Yoshi/View Controllers/Debug Date Picker View Controller/DebugDatePickerViewController.swift
+++ b/Yoshi/Yoshi/View Controllers/Debug Date Picker View Controller/DebugDatePickerViewController.swift
@@ -9,9 +9,6 @@
 /// The date picker view controller.
 internal class DebugDatePickerViewController: UIViewController {
 
-    /// The initial date.
-    var date = NSDate()
-
     private var selectorMenu: YoshiDateSelectorMenu?
 
     @IBOutlet private weak var datePicker: UIDatePicker!
@@ -47,7 +44,7 @@ internal class DebugDatePickerViewController: UIViewController {
     // MARK: - Private Functions
 
     private func setupDatePicker() {
-        datePicker.date = date
+        datePicker.date = selectorMenu?.selectedDate ?? NSDate()
         navigationItem.title = selectorMenu?.title
 
         let closeButton = UIBarButtonItem(title: "Apply", style: .Plain, target: self, action: "apply:")
@@ -58,6 +55,7 @@ internal class DebugDatePickerViewController: UIViewController {
 
     @objc private func apply(sender: UIBarButtonItem) {
         let date = datePicker.date
+        selectorMenu?.selectedDate = date
         selectorMenu?.didUpdateDate(dateSelected:date)
         navigationController?.popViewControllerAnimated(true)
     }

--- a/Yoshi/Yoshi/YoshiDateSelectorMenu.swift
+++ b/Yoshi/Yoshi/YoshiDateSelectorMenu.swift
@@ -9,7 +9,10 @@
 /**
  Protocol for defining a menu option for choosing a date.
  */
-public protocol YoshiDateSelectorMenu: YoshiMenu {
+public protocol YoshiDateSelectorMenu: class, YoshiMenu {
+    
+    /// The selected date.
+    var selectedDate: NSDate { get set }
 
     /// Function to handle the date selection.
     var didUpdateDate: (dateSelected: NSDate) -> () { get }
@@ -29,7 +32,6 @@ public extension YoshiDateSelectorMenu {
             DebugDatePickerViewController(nibName: String(DebugDatePickerViewController), bundle: bundle)
         datePickerViewController.modalPresentationStyle = .FormSheet
         datePickerViewController.setup(self)
-        datePickerViewController.date = NSDate()
 
         return .PresentViewController(datePickerViewController)
     }


### PR DESCRIPTION
This adds a selection for dates in a similar manner as PR #31.
* Added `selectedDate` as a stored variable for the (now class-only) protocol `YoshiDateSelectorMenu`.
* Set the selected date for a new `DebugDatePickerViewController` to the last selected date.