### PR TITLE
Added support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+# references:
+# * http://www.objc.io/issue-6/travis-ci.html
+# * https://github.com/supermarin/xcpretty#usage
+
+language: objective-c
+osx_image: xcode7.3
+# cache: cocoapods
+# podfile: Example/Podfile
+# before_install:
+# - gem install cocoapods # Since Travis is not always on latest version
+# - pod install --project-directory=Example
+script:
+- set -o pipefail && xcodebuild test -project Yoshi/Yoshi.xcodeproj -scheme YoshiTests -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty
+- pod lib lint

--- a/Yoshi/Yoshi.xcodeproj/xcshareddata/xcschemes/YoshiTests.xcscheme
+++ b/Yoshi/Yoshi.xcodeproj/xcshareddata/xcschemes/YoshiTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "276BCEAA1C29A6EF002138C7"
+               BuildableName = "YoshiTests.xctest"
+               BlueprintName = "YoshiTests"
+               ReferencedContainer = "container:Yoshi.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
This adds the missing .travis.yml and test scheme to work with Travis CI.

Currently, Travis will fail, as there are several warnings: 
```
    - WARN  | description: The description is equal to the summary.
    - WARN  | xcodebuild:  /Users/travis/build/DannyVancura/Yoshi/Yoshi/Yoshi/View Controllers/Debug Date Picker View Controller/DebugDatePickerViewController.swift:50:96: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
    - WARN  | xcodebuild:  /Users/travis/build/DannyVancura/Yoshi/Yoshi/Yoshi/View Controllers/Debug View Controller/DebugViewController.swift:104:96: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead

[!] Yoshi did not pass validation, due to 3 warnings (but you can use `--allow-warnings` to ignore them).
```

It would be either possible to 
* ignore these (as described in the output), 
* change the Xcode version in .travis.yml to `xcode7.2` 
* or upgrade the code base to Swift 2.2.