### PR TITLE
Updated date selector and table view menus to have default subtitles

### DIFF
--- a/Example/YoshiExample/AppDelegate.swift
+++ b/Example/YoshiExample/AppDelegate.swift
@@ -37,7 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let environmentItems: [YoshiTableViewMenuItem] = [menuItemProd, menuItemStaging, menuItemQA]
 
         let tableViewMenu = TableViewMenu(title: "Environment",
-            subtitle: "Use to switch backend environments",
+            subtitle: nil,
             displayItems: environmentItems, didSelectDisplayItem: { (displayItem) in
             NSNotificationCenter.defaultCenter()
                 .postNotificationName(Notifications.EnvironmentUpdatedNotification, object: displayItem.name)
@@ -45,7 +45,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // YoshiMenuType.DateSelector
         let dateSelector = DateSelector(title: "Environment Date",
-            subtitle: "Use to switch the date sent in HTTP headers",
+            subtitle: nil,
             didUpdateDate: { (dateSelected) in
             NSNotificationCenter.defaultCenter()
                 .postNotificationName(Notifications.EnvironmentDateUpdatedNotification, object: dateSelected)

--- a/Example/YoshiExample/ViewController.swift
+++ b/Example/YoshiExample/ViewController.swift
@@ -13,8 +13,13 @@ internal final class ViewController: UIViewController {
     @IBOutlet private weak var environment: UILabel!
     @IBOutlet private weak var environmentDate: UILabel!
 
+    private let dateFormatter: NSDateFormatter = NSDateFormatter()
+
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        dateFormatter.dateStyle = .MediumStyle
+        dateFormatter.timeStyle = .ShortStyle
 
         NSNotificationCenter.defaultCenter()
             .addObserver(self,
@@ -46,7 +51,7 @@ internal final class ViewController: UIViewController {
             return
         }
 
-        self.environmentDate.text = environmentDate.description
+        self.environmentDate.text = dateFormatter.stringFromDate(environmentDate)
     }
 
 }

--- a/Yoshi/Yoshi/View Controllers/Debug View Controller/DebugViewController.swift
+++ b/Yoshi/Yoshi/View Controllers/Debug View Controller/DebugViewController.swift
@@ -15,6 +15,8 @@ internal final class DebugViewController: UIViewController {
 
     private let tableView = UITableView()
     private let options: [YoshiMenu]
+    
+    private let dateFormatter: NSDateFormatter = NSDateFormatter()
 
     init(options: [YoshiMenu], completion: (VoidCompletionBlock?) -> Void) {
         self.options = options
@@ -30,6 +32,11 @@ internal final class DebugViewController: UIViewController {
         view = UIView()
         setupNavigationController()
         setupTableView()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupDateFormatter()
     }
 
     override func viewWillAppear(animated: Bool) {
@@ -108,6 +115,11 @@ internal final class DebugViewController: UIViewController {
         navigationItem.leftBarButtonItem = closeButton
         navigationItem.title = AppBundleUtility.appDisplayName()
     }
+    
+    private func setupDateFormatter() {
+        dateFormatter.dateStyle = .MediumStyle
+        dateFormatter.timeStyle = .ShortStyle
+    }
 
     @objc private func close(sender: UIBarButtonItem) {
         completionHandler(completed: nil)
@@ -137,14 +149,10 @@ extension DebugViewController: UITableViewDataSource {
         } else {
             switch option {
             case let dateSelectorMenu as YoshiDateSelectorMenu:
-                cell.detailTextLabel?.text = dateSelectorMenu.selectedDate.description
-            case let tableViewMenu as YoshiTableViewMenu:                
-                for displayItem in tableViewMenu.displayItems {
-                    if displayItem.selected == true {
-                        cell.detailTextLabel?.text = displayItem.name
-                        break
-                    }
-                }
+                cell.detailTextLabel?.text = dateFormatter.stringFromDate(dateSelectorMenu.selectedDate)
+            case let tableViewMenu as YoshiTableViewMenu:
+                let selectedDisplayItem = tableViewMenu.displayItems.filter { $0.selected == true }.first
+                cell.detailTextLabel?.text = selectedDisplayItem?.name
             default:
                 cell.detailTextLabel?.text = nil
             }

--- a/Yoshi/Yoshi/View Controllers/Debug View Controller/DebugViewController.swift
+++ b/Yoshi/Yoshi/View Controllers/Debug View Controller/DebugViewController.swift
@@ -131,8 +131,25 @@ extension DebugViewController: UITableViewDataSource {
 
         let option = options[indexPath.row]
         cell.textLabel?.text = option.title
-        cell.detailTextLabel?.text = option.subtitle
-
+        
+        if let subtitle = option.subtitle {
+            cell.detailTextLabel?.text = subtitle
+        } else {
+            switch option {
+            case let dateSelectorMenu as YoshiDateSelectorMenu:
+                cell.detailTextLabel?.text = dateSelectorMenu.selectedDate.description
+            case let tableViewMenu as YoshiTableViewMenu:                
+                for displayItem in tableViewMenu.displayItems {
+                    if displayItem.selected == true {
+                        cell.detailTextLabel?.text = displayItem.name
+                        break
+                    }
+                }
+            default:
+                cell.detailTextLabel?.text = nil
+            }
+        }
+        
         switch option {
         case _ as YoshiDateSelectorMenu:
             cell.accessoryType = .DisclosureIndicator


### PR DESCRIPTION
Updated date selector and table view menus to have default subtitles. For date selectors, the default subtitle is the selected date and for table views, it's the first option that's marked selected.