### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ internal final class MenuItem: YoshiTableViewMenuItem {
 Then, set up the menu and present it using Yoshi.
 
 ```swift
-let menuItemProd = MenuItem(name: "Production")
-let menuItemStaging = MenuItem(name: "Staging")
-let menuItemQA = MenuItem(name: "QA", selected: true)
-let environmentItems: [YoshiTableViewMenuItem] = [menuItemProd, menuItemStaging, menuItemQA]
+let production = MenuItem(name: "Production")
+let staging = MenuItem(name: "Staging")
+let qa = MenuItem(name: "QA", selected: true)
+let environmentItems: [YoshiTableViewMenuItem] = [production, staging, qa]
 
 let tableViewMenu = TableViewMenu(title: "Environment",
   subtitle: nil,

--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ Yoshi.show()
 
 In addition to the vanilla invocation option, Yoshi can also be invoked in response to motion or touch events. To do this, simply forward the motion and touch-related `UIResponder` events to their corresponding Yoshi event-handling functions.
 
+For example, we can start Yoshi in response to a shake-motion gesture by overriding and forwarding `motionBegan:withEvent:` function as follows.
+
+```swift
+override func motionBegan(motion: UIEventSubtype, withEvent event: UIEvent?) {
+    Yoshi.motionBegan(motion, withEvent: event)
+}
+```
+
 ## Contributing to Yoshi
 
 To report a bug or enhancement request, feel free to file an issue under the respective heading.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Yoshi can be set up to display any sort of menu as long as the menu object confo
 
 ### List Menu
 
-To display a list menu, create two types that conform to `YoshiTableViewMenu` to `YoshiTableViewMenuItem` protocols respectively.
+To display a list menu, create two types that conform to `YoshiTableViewMenu` and `YoshiTableViewMenuItem` protocols respectively.
 
 ```swift
 struct TableViewMenu: YoshiTableViewMenu {

--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ Yoshi.setupDebugMenu([instabugMenu])
 Yoshi.show()
 ```
 
+### Invocation Options
+
+In addition to the vanilla invocation option, Yoshi can also be invoked in response to motion or touch events. To do this, simply forward the motion and touch-related `UIResponder` events to their corresponding Yoshi event-handling functions.
+
 ## Contributing to Yoshi
 
 To report a bug or enhancement request, feel free to file an issue under the respective heading.

--- a/README.md
+++ b/README.md
@@ -72,12 +72,10 @@ If you wish to contribute to the project, fork this repo and submit a pull reque
 
 ## License
 
-Yoshi is Copyright (c) 2016 Prolific Interactive. It may be redistributed under the terms specified in the [LICENSE] file.
-
-[LICENSE]: /LICENSE
-
-## Maintainers
-
 ![prolific](https://s3.amazonaws.com/prolificsitestaging/logos/Prolific_Logo_Full_Color.png)
 
-Yoshi is maintained and funded by Prolific Interactive. The names and logos are trademarks of Prolific Interactive.
+Copyright (c) 2016 Prolific Interactive
+
+Yoshi is maintained and sponsored by Prolific Interactive. It may be redistributed under the terms specified in the [LICENSE] file.
+
+[LICENSE]: ./LICENSE

--- a/README.md
+++ b/README.md
@@ -42,14 +42,43 @@ github "prolificinteractive/Yoshi"
 
 ## Usage
 
-A common use case for Yoshi would be to present a menu for API environment switching. Yoshi takes care of presenting the UI for environment selection and calls the convenient closure function when a selection is made.
+Yoshi can be set up to display any sort of menu as long as the menu object conforms to `YoshiMenu`. Yoshi comes with two built-in menus: list menu and date menu.
+
+### List Menu
+
+To display a list menu, create two types that conform to `YoshiTableViewMenu` to `YoshiTableViewMenuItem` protocols respectively.
 
 ```swift
-import Yoshi
+struct TableViewMenu: YoshiTableViewMenu {
 
-let menuItemProd = MenuItem(name: "Production")
+    var title: String
+    var subtitle: String?
+    var displayItems: [YoshiTableViewMenuItem]
+    var didSelectDisplayItem: (displayItem: YoshiTableViewMenuItem) -> ()
+
+}
+
+internal final class MenuItem: YoshiTableViewMenuItem {
+
+    let name: String
+    var selected: Bool
+
+    init(name: String,
+         selected: Bool = false) {
+        self.name = name
+        self.selected = selected
+    }
+
+}
+```
+
+Then, set up the menu and present it using Yoshi.
+
+```swift
+let menuItemProd = MenuItem(name: "Production", selected: true)
 let menuItemStaging = MenuItem(name: "Staging")
-let environmentItems: [YoshiTableViewMenuItem] = [menuItemProd, menuItemStaging]
+let menuItemQA = MenuItem(name: "QA")
+let environmentItems: [YoshiTableViewMenuItem] = [menuItemProd, menuItemStaging, menuItemQA]
 
 let tableViewMenu = TableViewMenu(title: "Environment",
   subtitle: nil,
@@ -61,7 +90,80 @@ let tableViewMenu = TableViewMenu(title: "Environment",
 Yoshi.setupDebugMenu([tableViewMenu])
 
 // Invoke Yoshi
-Yoshi.showDebugActionSheet()
+Yoshi.show()
+```
+
+Yoshi will take care of managing selections and call back the convenient closure function when a new selection is made.
+
+### Date Selector Menu
+
+Similarly, to present a date selector menu, create a type that conforms to `YoshiDateSelectorMenu` protocol
+
+```swift
+internal final class DateSelector: YoshiDateSelectorMenu {
+
+    var title: String
+    var subtitle: String?
+    var selectedDate: NSDate
+    var didUpdateDate: (dateSelected: NSDate) -> ()
+
+    init(title: String,
+         subtitle: String? = nil,
+         selectedDate: NSDate = NSDate(),
+         didUpdateDate: (NSDate) -> ()) {
+        self.title = title
+        self.subtitle = subtitle
+        self.selectedDate = selectedDate
+        self.didUpdateDate = didUpdateDate
+    }
+
+}
+```
+
+and present it using the same functions.
+
+```swift
+let dateSelectorMenu = DateSelector(title: "Environment Date",
+    subtitle: nil,
+    didUpdateDate: { (dateSelected) in
+    NSNotificationCenter.defaultCenter()
+        .postNotificationName(Notifications.EnvironmentDateUpdatedNotification, object: dateSelected)
+})
+
+Yoshi.setupDebugMenu([dateSelectorMenu])
+Yoshi.show()
+```
+
+### Custom Menu
+
+Yoshi can also be configured to display custom menus which can be used for triggering custom events or presenting custom view controllers.
+
+For example, we can invoke [Instabug](https://instabug.com) when a custom menu is selected.
+
+```swift
+private struct CustomMenu: YoshiMenu {
+
+    let title: String
+    let subtitle: String?
+    let completion: () -> ()
+
+    func execute() -> YoshiActionResult {
+        return .AsyncAfterDismissing(completion)
+    }
+
+}
+
+Instabug.startWithToken("abcdefghijklmnopqrstuvwxyz", invocationEvent: .None)
+Instabug.setDefaultInvocationMode(.BugReporter)
+
+let instabugMenu = CustomMenu(title: "Start Instabug",
+    subtitle: nil,
+    completion: {
+        Instabug.invoke()
+    })
+
+Yoshi.setupDebugMenu([instabugMenu])
+Yoshi.show()
 ```
 
 ## Contributing to Yoshi

--- a/README.md
+++ b/README.md
@@ -167,15 +167,37 @@ Yoshi.show()
 
 ### Invocation Options
 
+Yoshi can be invoked a number of different ways. The simplest way is to manually invoke using the `show()` function.
+
+```swift
+Yoshi.show()
+```
+
 In addition to the vanilla invocation option, Yoshi can also be invoked in response to motion or touch events. To do this, simply forward the motion and touch-related `UIResponder` events to their corresponding Yoshi event-handling functions.
 
-For example, we can start Yoshi in response to a shake-motion gesture by overriding and forwarding `motionBegan:withEvent:` function as follows.
+To invoke Yoshi in response to a shake-motion gesture, override and forward `motionBegan:withEvent:` function as follows.
 
 ```swift
 override func motionBegan(motion: UIEventSubtype, withEvent event: UIEvent?) {
     Yoshi.motionBegan(motion, withEvent: event)
 }
 ```
+
+To invoke Yoshi in in response to a multi-touch event, override and forward `touchesBegan:withEvent:` function. Optionally, the minimum number of touches required for invocation can be specified.
+
+```swift
+override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {
+    Yoshi.touchesBegan(touches, withEvent: event)
+}
+```
+
+Finally, to invoke Yoshi in response to a 3D touch event, override and forward `touchesMoved:withEvent:` function with `minimumForcePercent` as an optional parameter.
+
+```swift
+override func touchesMoved(touches: Set<UITouch>, withEvent event: UIEvent?) {
+    Yoshi.touchesMoved(touches, withEvent: event)
+}
+````
 
 ## Contributing to Yoshi
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ internal final class MenuItem: YoshiTableViewMenuItem {
 Then, set up the menu and present it using Yoshi.
 
 ```swift
-let menuItemProd = MenuItem(name: "Production", selected: true)
+let menuItemProd = MenuItem(name: "Production")
 let menuItemStaging = MenuItem(name: "Staging")
-let menuItemQA = MenuItem(name: "QA")
+let menuItemQA = MenuItem(name: "QA", selected: true)
 let environmentItems: [YoshiTableViewMenuItem] = [menuItemProd, menuItemStaging, menuItemQA]
 
 let tableViewMenu = TableViewMenu(title: "Environment",
@@ -126,8 +126,7 @@ and present it using the same functions.
 let dateSelectorMenu = DateSelector(title: "Environment Date",
     subtitle: nil,
     didUpdateDate: { (dateSelected) in
-    NSNotificationCenter.defaultCenter()
-        .postNotificationName(Notifications.EnvironmentDateUpdatedNotification, object: dateSelected)
+      // Do something with the selected date here
 })
 
 Yoshi.setupDebugMenu([dateSelectorMenu])
@@ -136,7 +135,7 @@ Yoshi.show()
 
 ### Custom Menu
 
-Yoshi can also be configured to display custom menus which can be used for triggering custom events or presenting custom view controllers.
+Yoshi can also be configured to display custom menus which can be used for triggering events or presenting view controllers.
 
 For example, we can invoke [Instabug](https://instabug.com) when a custom menu is selected.
 

--- a/Yoshi.podspec
+++ b/Yoshi.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
   s.name             = "Yoshi"
   s.version          = "1.0.0"
-  s.summary          = "In app debug panel for iOS"
+  s.summary          = "A helpful companion for your iOS app."
 
 # This description is used to generate tags and improve search results.
 #   * Think: What does it do? Why did you write it? What is the focus?
@@ -17,8 +17,6 @@ Pod::Spec.new do |s|
 #   * Write the description between the DESC delimiters below.
 #   * Finally, don't worry about the indent, CocoaPods strips it!
   s.description      = <<-DESC
-		       A helpful companion for your iOS app.
-
 		       Yoshi is a convenient wrapper around the UI code that is often needed for displaying debug menus. Out of the box, Yoshi provides easy-to-implement date, list and custom menus.
                        DESC
 


### PR DESCRIPTION
Updated the license section to match the latest Prolific template. Also expanded the usage section to include date and custom menu examples.