### PR TITLE
Remove UIWindow extension default access to avoid hiding open functions.

### DIFF
--- a/Yoshi/Yoshi/Utility/UIWindowExtension.swift
+++ b/Yoshi/Yoshi/Utility/UIWindowExtension.swift
@@ -10,7 +10,7 @@ import UIKit
 
 
 // MARK: - UIWindow Extension.
-public extension UIWindow {
+extension UIWindow {
 
     /// Function returning the amount of touch required to show Yoshi from a mulitple touch.
     /// Override this function to update the value.


### PR DESCRIPTION
With the extension marked as `public`, the `open` functions are quietly downgraded to `public`, meaning that any `UIWindow` subclass can no longer override these functions.