### PR TITLE
Add the ability of getting a debug navigation controller without call…

### DIFF
--- a/Yoshi/Yoshi/Yoshi.swift
+++ b/Yoshi/Yoshi/Yoshi.swift
@@ -96,6 +96,13 @@ public final class Yoshi {
     public class func show() {
         YoshiConfigurationManager.sharedInstance.show()
     }
+    
+    /// Return a navigation controller presenting the debug view controller.
+    ///
+    /// - Returns: Debug navigation controller
+    public class func debugNavigationController() -> UINavigationController {
+        return YoshiConfigurationManager.sharedInstance.debugNavigationController()
+    }
 
     /**
      Dismisses the debug menu, if it is opened. The input block is executed after it has dismissed.

--- a/Yoshi/Yoshi/YoshiConfigurationManager.swift
+++ b/Yoshi/Yoshi/YoshiConfigurationManager.swift
@@ -74,6 +74,22 @@ internal final class YoshiConfigurationManager {
         }
     }
 
+    /// Return a navigation controller presenting the debug view controller.
+    ///
+    /// - Returns: Debug navigation controller
+    func debugNavigationController() -> UINavigationController {
+        let navigationController = UINavigationController()
+
+        let debugViewController = DebugViewController(options: yoshiMenuItems, completion: { _ in
+            navigationController.dismiss(animated: true)
+        })
+        self.debugViewController = debugViewController
+
+        navigationController.setViewControllers([debugViewController], animated: false)
+
+        return navigationController
+    }
+
     /**
      Dismisses the debug view controller, if possible.
 


### PR DESCRIPTION
…ing .

This feature can be useful in the case you don't want to display a new UIWindows (i.e. you can't add a new Window in an iMessage app).