### PR TITLE
Fix the Reusable typo

### DIFF
--- a/Example/YoshiExample/MenuItem.swift
+++ b/Example/YoshiExample/MenuItem.swift
@@ -81,7 +81,7 @@ internal struct CustomMenu: YoshiMenu {
 /// A menu with custom UI
 internal struct MenuWithCustomUI: YoshiGenericMenu {
 
-    var cellSource: YoshiResuableCellDataSource {
+    var cellSource: YoshiReusableCellDataSource {
         return CustomMenuCellDataSource()
     }
 
@@ -91,7 +91,7 @@ internal struct MenuWithCustomUI: YoshiGenericMenu {
 }
 
 /// Datasource for MenuWithCustomUI to dequeue CustomCell
-internal final class CustomMenuCellDataSource: YoshiResuableCellDataSource {
+internal final class CustomMenuCellDataSource: YoshiReusableCellDataSource {
 
     static var nib: UINib? {
         return UINib(nibName: "CustomCell", bundle: nil)

--- a/Yoshi/Yoshi.xcodeproj/project.pbxproj
+++ b/Yoshi/Yoshi.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 		32AA07501E60D38B001516EA /* YoshiTableViewMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AA07481E60D38B001516EA /* YoshiTableViewMenuItem.swift */; };
 		32AA07541E60D417001516EA /* YoshiDateSelectorMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AA07521E60D417001516EA /* YoshiDateSelectorMenu.swift */; };
 		32AA07551E60D417001516EA /* YoshiDateSelectorMenuCellDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AA07531E60D417001516EA /* YoshiDateSelectorMenuCellDataSource.swift */; };
-		32AA07571E60D5C3001516EA /* YoshiResuableCellDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AA07561E60D5C3001516EA /* YoshiResuableCellDataSource.swift */; };
+		32AA07571E60D5C3001516EA /* YoshiReusableCellDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AA07561E60D5C3001516EA /* YoshiReusableCellDataSource.swift */; };
 		664DA24C1DFB3A97007F6840 /* UITableViewCellExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664DA24B1DFB3A97007F6840 /* UITableViewCellExtension.swift */; };
 		664E30721DBE970000C313C2 /* UIWindowExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664E30711DBE970000C313C2 /* UIWindowExtension.swift */; };
 		664E30761DBEA72700C313C2 /* YoshiInvocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664E30751DBEA72700C313C2 /* YoshiInvocation.swift */; };
@@ -62,7 +62,7 @@
 		32AA07481E60D38B001516EA /* YoshiTableViewMenuItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YoshiTableViewMenuItem.swift; sourceTree = "<group>"; };
 		32AA07521E60D417001516EA /* YoshiDateSelectorMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YoshiDateSelectorMenu.swift; sourceTree = "<group>"; };
 		32AA07531E60D417001516EA /* YoshiDateSelectorMenuCellDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YoshiDateSelectorMenuCellDataSource.swift; sourceTree = "<group>"; };
-		32AA07561E60D5C3001516EA /* YoshiResuableCellDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YoshiResuableCellDataSource.swift; sourceTree = "<group>"; };
+		32AA07561E60D5C3001516EA /* YoshiReusableCellDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YoshiReusableCellDataSource.swift; sourceTree = "<group>"; };
 		664DA24B1DFB3A97007F6840 /* UITableViewCellExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITableViewCellExtension.swift; sourceTree = "<group>"; };
 		664E30711DBE970000C313C2 /* UIWindowExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIWindowExtension.swift; path = Utility/UIWindowExtension.swift; sourceTree = "<group>"; };
 		664E30751DBEA72700C313C2 /* YoshiInvocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YoshiInvocation.swift; sourceTree = "<group>"; };
@@ -152,7 +152,7 @@
 				F902ED2D1C694529007975F5 /* YoshiConfigurationManager.swift */,
 				664E30751DBEA72700C313C2 /* YoshiInvocation.swift */,
 				9498B6C91E5E82B9005CD1D8 /* YoshiGenericMenu.swift */,
-				32AA07561E60D5C3001516EA /* YoshiResuableCellDataSource.swift */,
+				32AA07561E60D5C3001516EA /* YoshiReusableCellDataSource.swift */,
 			);
 			path = Yoshi;
 			sourceTree = "<group>";
@@ -370,7 +370,7 @@
 				664E30721DBE970000C313C2 /* UIWindowExtension.swift in Sources */,
 				276BCEBE1C29A97E002138C7 /* DebugTableViewController.swift in Sources */,
 				9498B6CA1E5E82B9005CD1D8 /* YoshiGenericMenu.swift in Sources */,
-				32AA07571E60D5C3001516EA /* YoshiResuableCellDataSource.swift in Sources */,
+				32AA07571E60D5C3001516EA /* YoshiReusableCellDataSource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Yoshi/Yoshi/Menus/YoshiDateSelectorMenu/YoshiDateSelectorMenu.swift
+++ b/Yoshi/Yoshi/Menus/YoshiDateSelectorMenu/YoshiDateSelectorMenu.swift
@@ -22,7 +22,7 @@ public protocol YoshiDateSelectorMenu: class, YoshiMenu {
 public extension YoshiDateSelectorMenu {
 
     /// Data source for the date selector style cell
-    var cellSource: YoshiResuableCellDataSource {
+    var cellSource: YoshiReusableCellDataSource {
         return YoshiDateSelectorMenuCellDataSource(title: title, date: selectedDate)
     }
 

--- a/Yoshi/Yoshi/Menus/YoshiDateSelectorMenu/YoshiDateSelectorMenuCellDataSource.swift
+++ b/Yoshi/Yoshi/Menus/YoshiDateSelectorMenu/YoshiDateSelectorMenuCellDataSource.swift
@@ -7,7 +7,7 @@
 //
 
 /// Cell data source defining the layout for YoshiDateSelectorMenu's cell
-internal struct YoshiDateSelectorMenuCellDataSource: YoshiResuableCellDataSource {
+internal struct YoshiDateSelectorMenuCellDataSource: YoshiReusableCellDataSource {
 
     private let title: String
 

--- a/Yoshi/Yoshi/Menus/YoshiMenu/YoshiMenu.swift
+++ b/Yoshi/Yoshi/Menus/YoshiMenu/YoshiMenu.swift
@@ -21,7 +21,7 @@ public protocol YoshiMenu: YoshiGenericMenu {
 public extension YoshiMenu {
 
     /// Default implementation for the cell data source, it will use the system cell with the given title and subtitle
-    var cellSource: YoshiResuableCellDataSource {
+    var cellSource: YoshiReusableCellDataSource {
         return YoshiMenuCellDataSource(title: title, subtitle: subtitle)
     }
 }

--- a/Yoshi/Yoshi/Menus/YoshiMenu/YoshiMenuCellDataSource.swift
+++ b/Yoshi/Yoshi/Menus/YoshiMenu/YoshiMenuCellDataSource.swift
@@ -7,7 +7,7 @@
 //
 
 /// Cell data source defining the layout for YoshiMenu's cell
-internal struct YoshiMenuCellDataSource: YoshiResuableCellDataSource {
+internal struct YoshiMenuCellDataSource: YoshiReusableCellDataSource {
 
     private let title: String
 

--- a/Yoshi/Yoshi/Menus/YoshiTableViewMenu/YoshiTableViewMenu.swift
+++ b/Yoshi/Yoshi/Menus/YoshiTableViewMenu/YoshiTableViewMenu.swift
@@ -21,7 +21,7 @@ public protocol YoshiTableViewMenu: YoshiMenu {
 
 public extension YoshiTableViewMenu {
 
-    var cellSource: YoshiResuableCellDataSource {
+    var cellSource: YoshiReusableCellDataSource {
         let selectedDisplayItem = displayItems.filter { $0.selected == true }.first
         let subtitle = selectedDisplayItem?.name
         return YoshiMenuCellDataSource(title: title, subtitle: subtitle)

--- a/Yoshi/Yoshi/View Controllers/Debug View Controller/DebugViewController.swift
+++ b/Yoshi/Yoshi/View Controllers/Debug View Controller/DebugViewController.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Prolific Interactive. All rights reserved.
 //
 
-internal typealias VoidCompletionBlock = (Void) -> Void
+internal typealias VoidCompletionBlock = () -> Void
 
 /// A debug menu.
 internal final class DebugViewController: UIViewController {

--- a/Yoshi/Yoshi/Yoshi.swift
+++ b/Yoshi/Yoshi/Yoshi.swift
@@ -109,7 +109,7 @@ public final class Yoshi {
 
      - parameter completion: The block to execute upon completion of dismissal.
      */
-    public class func dismiss(_ completion: ((Void) -> Void)? = nil) {
+    public class func dismiss(_ completion: (() -> Void)? = nil) {
         YoshiConfigurationManager.sharedInstance.dismiss(completion)
     }
 

--- a/Yoshi/Yoshi/YoshiGenericMenu.swift
+++ b/Yoshi/Yoshi/YoshiGenericMenu.swift
@@ -12,7 +12,7 @@
 public protocol YoshiGenericMenu {
 
     /// Reuse identifier for the cell.
-    var cellSource: YoshiResuableCellDataSource { get }
+    var cellSource: YoshiReusableCellDataSource { get }
 
     /**
      Function to execute when the menu item is seleted.

--- a/Yoshi/Yoshi/YoshiReusableCellDataSource.swift
+++ b/Yoshi/Yoshi/YoshiReusableCellDataSource.swift
@@ -1,5 +1,5 @@
 //
-//  YoshiResuableCellDataSource.swift
+//  YoshiReusableCellDataSource.swift
 //  Yoshi
 //
 //  Created by Kanglei Fang on 24/02/2017.
@@ -7,7 +7,7 @@
 //
 
 /// Defines the data source for DebugViewController custom cell
-public protocol YoshiResuableCellDataSource {
+public protocol YoshiReusableCellDataSource {
 
     /// Reuse identifier for the cell
     static var reuseIdentifier: String { get }
@@ -25,7 +25,7 @@ public protocol YoshiResuableCellDataSource {
     func cellFor(tableView: UITableView) -> UITableViewCell
 }
 
-public extension YoshiResuableCellDataSource {
+public extension YoshiReusableCellDataSource {
 
     /// Default reuseIdentifier implementation, it will use the protocol adopator's name
     static var reuseIdentifier: String {


### PR DESCRIPTION
Fix the class name `YoshiReusableCellDataSource`. 
Since it's a public class, this might have impact on previous versions, but should be easy to fix