### PR TITLE
Restart Yoshi

### DIFF
--- a/Yoshi/Yoshi/Yoshi.swift
+++ b/Yoshi/Yoshi/Yoshi.swift
@@ -21,6 +21,14 @@ public final class Yoshi {
         YoshiConfigurationManager.sharedInstance.setupDebugMenuOptions(menuItems, invocations: invocations)
     }
 
+    /**
+     Allows client application to indicate it has restarted.
+     Clears inertnal state.
+     */
+    public static func restart() {
+        YoshiConfigurationManager.sharedInstance.restart()
+    }
+    
     // MARK: - Invocation Functions
 
     /**

--- a/Yoshi/Yoshi/YoshiConfigurationManager.swift
+++ b/Yoshi/Yoshi/YoshiConfigurationManager.swift
@@ -27,6 +27,21 @@ internal final class YoshiConfigurationManager {
         yoshiMenuItems = menuItems
         self.invocations = invocations
     }
+    
+    /**
+     Allows client application to indicate it has restarted.
+     Clears inertnal state.
+     */
+    func restart() {
+        presentingWindow = nil
+        debugViewController = nil
+        
+        guard let invocations = invocations else {
+            return
+        }
+        
+        setupDebugMenuOptions(yoshiMenuItems, invocations: invocations)
+    }
 
     /// Helper function to indicate if the given invocation should show Yoshi.
     ///


### PR DESCRIPTION
Noticed an issue when I reset the root window of my application - Yoshi was no longer presenting. It was because its `presentingWindow` was not `nil`. This PR adds a `restart()` function to clear internal state - client applications call this if they restart.

NOTE: This is pointing towards `release/2.0.2` because that is the version PCF is currently dependent on (cc @ThibaultKlein ); until PCF is updated to use the latest Yoshi version I'd like to keep this branch alive. Also, the latest version of Yoshi will need to preserve this behavior.