### PR TITLE
Update bottom constraint so menu is flush with bottom of iPhoneX

### DIFF
--- a/Yoshi/Yoshi/View Controllers/Debug View Controller/DebugViewController.swift
+++ b/Yoshi/Yoshi/View Controllers/Debug View Controller/DebugViewController.swift
@@ -56,10 +56,10 @@ internal final class DebugViewController: UIViewController {
             relatedBy: .equal, toItem: view, attribute: .top, multiplier: 1.0, constant: 0.0)
         let leadingConstraint = NSLayoutConstraint(item: tableView, attribute: .leading,
             relatedBy: .equal, toItem: view, attribute: .leading, multiplier: 1.0, constant: 0.0)
-        let trailingConstraint = NSLayoutConstraint(item: tableView,
-            attribute: .trailing, relatedBy: .equal, toItem: view, attribute: .trailing, multiplier: 1.0, constant: 0.0)
+        let trailingConstraint = NSLayoutConstraint(item: tableView, attribute: .trailing,
+            relatedBy: .equal, toItem: view, attribute: .trailing, multiplier: 1.0, constant: 0.0)
         let bottomConstraint = NSLayoutConstraint(item: tableView, attribute: .bottom,
-            relatedBy: .equal, toItem: bottomLayoutGuide, attribute: .top, multiplier: 1.0, constant: 0.0)
+            relatedBy: .equal, toItem: view, attribute: .bottom, multiplier: 1.0, constant: 0.0)
 
         view.addConstraints([topConstraint, leadingConstraint, trailingConstraint, bottomConstraint])
 


### PR DESCRIPTION
Adds support for iPhoneX, so there is no noticeable gap b/w bottom of the debug view controller and the screen.